### PR TITLE
stop gradient flow during dynamic routing coefficients calculation

### DIFF
--- a/deepcaps.py
+++ b/deepcaps.py
@@ -713,13 +713,14 @@ class CapsuleLayer(nn.Module):
         x = x.unsqueeze(2).unsqueeze(dim=4)
         
         u_hat = torch.matmul(self.W, x).squeeze()  # u_hat -> [batch_size, 32, 10, 32]
+        u_hat_detached = u_hat.detach() #detach the u_hat vector to stop the gradient flow during the calculation of the coefficients for dynamic routing.
         
         #   b_ij = torch.zeros((batch_size, self.num_routes, self.num_capsules, 1))
         b_ij = x.new(x.shape[0], self.num_routes, self.num_capsules, 1).zero_()
         
         for itr in range(self.routing_iters):
             c_ij = func.softmax(b_ij, dim=2)
-            s_j  = (c_ij * u_hat).sum(dim=1, keepdim=True) + self.bias
+            s_j  = (c_ij * u_hat_detached).sum(dim=1, keepdim=True) + self.bias #use detached u_hat during all the iteration except the final iteration.
             v_j  = squash(s_j, dim=-1)
             
             if itr < self.routing_iters-1:


### PR DESCRIPTION
The gradient flow on the u_hat vector has to be stopped during the calculation of the dynamic routing coefficients. Only during the last iteration of the dynamic routing, we enable the gradient flow. Source : https://github.com/naturomics/CapsNet-Tensorflow/blob/master/capsLayer.py line 119.